### PR TITLE
poppler 24.09.0: rebuild with libtiff 4.5.1 and licms2 2.16

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -7,4 +7,4 @@ channels:
   - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
   - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/b5361e3
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/af67ffc
-  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr1/ccc36ef
+  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr1/2c3b3cb

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,7 +4,7 @@ build_parameters:
 #  - "--error-overlinking"
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
-  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/eb9cc9b
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/822fcae
-  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr1/749c05c
+  # - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
+  # - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/eb9cc9b
+  # - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/822fcae
+  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr1/04efa45

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,9 +2,3 @@
 build_parameters:
   - "--suppress-variables"
 #  - "--error-overlinking"
-
-channels:
-  - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
-  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/b5361e3
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/af67ffc
-  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr1/2c3b3cb

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,8 @@ build_parameters:
   - "--suppress-variables"
 #  - "--error-overlinking"
 
+channels:
+  - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
+  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/eb9cc9b
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/822fcae
+  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr1/749c05c

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,7 +4,7 @@ build_parameters:
 #  - "--error-overlinking"
 
 channels:
-  # - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
-  # - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/eb9cc9b
-  # - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/822fcae
-  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr1/04efa45
+  - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
+  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/b5361e3
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/af67ffc
+  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr1/ccc36ef

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     folder: test_suite                                                                     # [not win]
 
 build:
-  number: 0
+  number: 1
   # Missing qt-main dependency for s390x.
   skip: true  # [s390x]
   detect_binary_files_with_prefix: true
@@ -36,6 +36,7 @@ build:
 
 requirements:
   build:
+    # gobject-introspection 1.* requires setuptools at runtime, but
     # setuptools >= 65.0.0 is lacking the msvccompiler module in distutils.
     # https://github.com/pypa/setuptools/pull/3505
     - setuptools <65
@@ -78,11 +79,11 @@ requirements:
     - gettext  # [osx]
     - glib
     - jpeg
-    - lcms2
+    - lcms2 2.16
     - libcurl
     - libiconv
     - libpng
-    - libtiff
+    - libtiff 4.5.1
     - nss  # [not win]
     - openjpeg
     - zlib
@@ -139,11 +140,11 @@ outputs:
         - gettext  # [osx]
         - glib
         - jpeg
-        - lcms2
+        - lcms2 2.16
         - libcurl
         - libiconv
         - libpng
-        - libtiff
+        - libtiff 4.5.1
         - nss  # [not win]
         - openjpeg
         - zlib
@@ -213,11 +214,11 @@ outputs:
         - gettext  # [osx]
         - glib
         - jpeg
-        - lcms2
+        - lcms2 2.16
         - libcurl
         - libiconv
         - libpng
-        - libtiff
+        - libtiff 4.5.1
         - nss  # [not win]
         - openjpeg
         - zlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,7 +83,9 @@ requirements:
     - libcurl
     - libiconv
     - libpng
-    - libtiff {{ libtiff }}
+    # libtiff 4.5.1 fixes a missing libtiff.lib on Windows
+    - libtiff 4.5.1          # [win]
+    - libtiff {{ libtiff }}  # [not win]
     - nss  # [not win]
     - openjpeg
     - zlib
@@ -144,7 +146,9 @@ outputs:
         - libcurl
         - libiconv
         - libpng
-        - libtiff {{ libtiff }}
+        # libtiff 4.5.1 fixes a missing libtiff.lib on Windows
+        - libtiff 4.5.1          # [win]
+        - libtiff {{ libtiff }}  # [not win]
         - nss  # [not win]
         - openjpeg
         - zlib
@@ -218,7 +222,9 @@ outputs:
         - libcurl
         - libiconv
         - libpng
-        - libtiff {{ libtiff }}
+        # libtiff 4.5.1 fixes a missing libtiff.lib on Windows
+        - libtiff 4.5.1          # [win]
+        - libtiff {{ libtiff }}  # [not win]
         - nss  # [not win]
         - openjpeg
         - zlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,9 +83,7 @@ requirements:
     - libcurl
     - libiconv
     - libpng
-    # libtiff 4.5.1 fixes a missing libtiff.lib on Windows
-    - libtiff 4.5.1          # [win]
-    - libtiff {{ libtiff }}  # [not win]
+    - libtiff {{ libtiff }}
     - nss  # [not win]
     - openjpeg
     - zlib
@@ -146,9 +144,7 @@ outputs:
         - libcurl
         - libiconv
         - libpng
-        # libtiff 4.5.1 fixes a missing libtiff.lib on Windows
-        - libtiff 4.5.1          # [win]
-        - libtiff {{ libtiff }}  # [not win]
+        - libtiff {{ libtiff }}
         - nss  # [not win]
         - openjpeg
         - zlib
@@ -222,9 +218,7 @@ outputs:
         - libcurl
         - libiconv
         - libpng
-        # libtiff 4.5.1 fixes a missing libtiff.lib on Windows
-        - libtiff 4.5.1          # [win]
-        - libtiff {{ libtiff }}  # [not win]
+        - libtiff {{ libtiff }}
         - nss  # [not win]
         - openjpeg
         - zlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,7 +83,7 @@ requirements:
     - libcurl
     - libiconv
     - libpng
-    - libtiff 4.5.1
+    - libtiff {{ libtiff }}
     - nss  # [not win]
     - openjpeg
     - zlib
@@ -144,7 +144,7 @@ outputs:
         - libcurl
         - libiconv
         - libpng
-        - libtiff 4.5.1
+        - libtiff {{ libtiff }}
         - nss  # [not win]
         - openjpeg
         - zlib
@@ -218,7 +218,7 @@ outputs:
         - libcurl
         - libiconv
         - libpng
-        - libtiff 4.5.1
+        - libtiff {{ libtiff }}
         - nss  # [not win]
         - openjpeg
         - zlib


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-5339](https://anaconda.atlassian.net/browse/PKG-6506)
- [Upstream repository](https://gitlab.freedesktop.org/poppler/poppler)
- [Upstream changelog/diff](https://gitlab.freedesktop.org/poppler/poppler/-/blob/poppler-24.09.0/NEWS?ref_type=tags)
- Requirements: 

### Explanation of changes:

- Bump the build number
- Pin libtiff to 4.5.1 and licms2 to 2.16

### Notes

- https://github.com/AnacondaRecipes/libtiff-feedstock/pull/20
- https://github.com/AnacondaRecipes/lcms2-feedstock/pull/1

[PKG-5339]: https://anaconda.atlassian.net/browse/PKG-5339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ