### PR TITLE
Rebuild for boost 1.88

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,5 @@
 build_parameters:
   - "--suppress-variables"
 #  - "--error-overlinking"
+channels:
+  - https://staging.continuum.io/prefect/fs/boost-feedstock/pr22/2dc38d9

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,5 +2,3 @@
 build_parameters:
   - "--suppress-variables"
 #  - "--error-overlinking"
-channels:
-  - https://staging.continuum.io/prefect/fs/boost-feedstock/pr22/2dc38d9

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,6 @@ requirements:
   host:
     # Need python to run glib-mkenums.
     - python 3.12  # [win]
-    - boost-cpp {{ boost_cpp }}
     - cairo {{ cairo }}
     - curl {{ libcurl }}
     - fontconfig {{ fontconfig }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -108,7 +108,6 @@ outputs:
         - openjpeg {{ openjpeg }}
         - zlib {{ zlib }}
       run:
-        - {{ pin_compatible('libboost-devel') }}
         - poppler-data
     files:
       - "Library/bin/poppler.dll"                      # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
     folder: test_suite                                                                     # [not win]
 
 build:
-  number: 3
+  number: 4
   detect_binary_files_with_prefix: true
 
 requirements:
@@ -49,6 +49,11 @@ requirements:
   host:
     # Need python to run glib-mkenums.
     - python 3.12  # [win]
+    # boost-python-devel is the new replacement for boost-cpp
+    - libboost-python-devel
+    - libboost-python
+    - libboost-devel
+    - libboost-headers
     - cairo {{ cairo }}
     - curl {{ libcurl }}
     - fontconfig {{ fontconfig }}
@@ -88,7 +93,10 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
       host:
-        - boost-cpp {{ boost_cpp }}
+        - libboost-python-devel
+        - libboost-python
+        - libboost-devel
+        - libboost-headers
         - cairo {{ cairo }}
         - curl {{ libcurl }}
         - fontconfig {{ fontconfig }}  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,7 @@ requirements:
     # Need python to run glib-mkenums.
     - python 3.12  # [win]
     # boost-python-devel is the new replacement for boost-cpp
+    - libboost
     - libboost-python-devel
     - libboost-python
     - libboost-devel
@@ -114,7 +115,7 @@ outputs:
         - openjpeg {{ openjpeg }}
         - zlib {{ zlib }}
       run:
-        - {{ pin_compatible('boost-cpp') }}
+        - {{ pin_compatible('libboost-devel') }}
         - poppler-data
     files:
       - "Library/bin/poppler.dll"                      # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,11 +50,7 @@ requirements:
     # Need python to run glib-mkenums.
     - python 3.12  # [win]
     # boost-python-devel is the new replacement for boost-cpp
-    - libboost
-    - libboost-python-devel
-    - libboost-python
-    - libboost-devel
-    - libboost-headers
+    - libboost-devel 1.88.0
     - cairo {{ cairo }}
     - curl {{ libcurl }}
     - fontconfig {{ fontconfig }}
@@ -94,10 +90,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
       host:
-        - libboost-python-devel
-        - libboost-python
-        - libboost-devel
-        - libboost-headers
+        - libboost-devel 1.88.0
         - cairo {{ cairo }}
         - curl {{ libcurl }}
         - fontconfig {{ fontconfig }}  # [unix]


### PR DESCRIPTION
## ☆ Poppler 24.09.0 Rebuild ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-8573) 
[Upstream](https://gitlab.freedesktop.org/poppler/poppler)

### Changes
* Rebuild for `boost 1.88.0`
* Updated boost dependencies from `boost-cpp` to `libboost-devel 1.88.0`
* Consolidated boost dependencies in host requirements
* Removed `pin_compatible` for `libboost-devel` from run dependencies