### PR TITLE
Rebuild against libjpeg-turbo

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
     folder: test_suite                                                                     # [not win]
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
 
 requirements:
@@ -54,7 +54,7 @@ requirements:
     - freetype {{ freetype }}
     - gettext {{ gettext }}  # [osx]
     - glib {{ glib }}
-    - jpeg {{ jpeg }}
+    - libjpeg-turbo {{ libjpeg_turbo }}
     - lcms2 {{ lcms2 }}
     - libcurl {{ libcurl }}
     - libiconv {{ libiconv }}
@@ -91,7 +91,7 @@ outputs:
         - freetype {{ freetype }}
         - gettext {{ gettext }}  # [osx]
         - glib {{ glib }}
-        - jpeg {{ jpeg }}
+        - libjpeg-turbo {{ libjpeg_turbo }}
         - lcms2 {{ lcms2 }}
         - libcurl {{ libcurl }}
         - libiconv {{ libiconv }}


### PR DESCRIPTION
poppler 26.04.0

**Destination channel:**  defaults

### Links

- [PKG-13228](https://anaconda.atlassian.net/browse/PKG-13228) 
- [Upstream repository](https://gitlab.freedesktop.org/poppler/poppler)

### Explanation of changes:
- Rebuild against libjpeg-turbo


[PKG-13228]: https://anaconda.atlassian.net/browse/PKG-13228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ